### PR TITLE
Fix(UserData): Redis 외부 접속 허용 및 인증 설정

### DIFF
--- a/modules/data/ec2-redis/main.tf
+++ b/modules/data/ec2-redis/main.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "db" {
     sudo systemctl enable --now redis-server
     REDIS_CONF="/etc/redis/redis.conf"
     REDIS_PASSWORD="password"
-    sudo sed -i 's/^bind 127.0.0.1 ::1/# bind 127.0.0.1 ::1/' "$REDIS_CONF"
+    sudo sed -i 's/^bind .*/bind 0.0.0.0/' "$REDIS_CONF"
     if grep -q "^# requirepass" "$REDIS_CONF"; then
         sudo sed -i "s/^# requirepass .*/requirepass $REDIS_PASSWORD/" "$REDIS_CONF"
     else


### PR DESCRIPTION
- redis.conf 내 bind 설정을 127.0.0.1 → 0.0.0.0 으로 수정하여 외부 접속 가능하도록 변경
- requirepass 적용으로 비밀번호 인증 강제
- UFW 포트(6379/tcp) 오픈 추가
- systemctl 재시작 포함해 EC2 User Data 실행 시 자동 반영되도록 수정